### PR TITLE
Let relative paths be resolved normally.

### DIFF
--- a/src/plugin.es5.js
+++ b/src/plugin.es5.js
@@ -85,6 +85,9 @@ var RollupIncludePaths = (function () {
     _createClass(RollupIncludePaths, [{
         key: 'resolveId',
         value: function resolveId(id, origin) {
+            if (/^\.{0,2}\//.test(id)) {
+                return null;
+            }
             origin = origin || false;
             return this.resolveCachedPath(id) || this.searchModule(id, origin);
         }
@@ -161,7 +164,7 @@ var RollupIncludePaths = (function () {
     }, {
         key: 'searchModule',
         value: function searchModule(file, origin) {
-            var newPath = this.searchRelativePath(file, origin) || this.searchProjectModule(file, origin);
+            var newPath = this.searchProjectModule(file, origin);
 
             if (newPath) {
                 // add result to cache
@@ -198,34 +201,6 @@ var RollupIncludePaths = (function () {
             }
 
             return null;
-        }
-
-        /**
-         * Sarch for a file relative to who required it
-         *
-         * @param {string} file         File path to search
-         * @param {string} [origin]     Origin of the module request
-         */
-    }, {
-        key: 'searchRelativePath',
-        value: function searchRelativePath(file, origin) {
-            if (!origin) {
-                return null;
-            }
-
-            var basePath = _path2['default'].dirname(origin);
-
-            return(
-                // common case
-                // require('./file.js') in 'path/origin.js'
-                // > path/file.js
-                this.resolvePath(_path2['default'].join(basePath, file), true) ||
-
-                // nodejs path case
-                // require('./subfolder') in 'lib/origin.js'
-                // > lib/subfolder/index.js
-                this.resolvePath(_path2['default'].join(basePath, file, 'index.js'), false)
-            );
         }
 
         /**

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -61,6 +61,9 @@ class RollupIncludePaths {
      * @param {string} [origin]     Origin of the module request
      */
     resolveId(id, origin) {
+        if (/^\.{0,2}\//.test(id)) {
+            return null;
+        }
         origin = origin || false;
         return this.resolveCachedPath(id) || this.searchModule(id, origin);
     }
@@ -130,9 +133,7 @@ class RollupIncludePaths {
      * @param {string} [origin]     Origin of the module request
      */
     searchModule (file, origin) {
-        let newPath =
-            this.searchRelativePath(file, origin) ||
-            this.searchProjectModule(file, origin);
+        let newPath = this.searchProjectModule(file, origin);
 
         if (newPath) {
             // add result to cache
@@ -167,32 +168,6 @@ class RollupIncludePaths {
         }
 
         return null;
-    }
-
-    /**
-     * Sarch for a file relative to who required it
-     *
-     * @param {string} file         File path to search
-     * @param {string} [origin]     Origin of the module request
-     */
-    searchRelativePath (file, origin) {
-        if (!origin) {
-            return null;
-        }
-
-        let basePath = path.dirname(origin);
-
-        return (
-            // common case
-            // require('./file.js') in 'path/origin.js'
-            // > path/file.js
-            this.resolvePath(path.join(basePath, file), true) ||
-
-            // nodejs path case
-            // require('./subfolder') in 'lib/origin.js'
-            // > lib/subfolder/index.js
-            this.resolvePath(path.join(basePath, file, 'index.js'), false)
-        );
     }
 
     /**


### PR DESCRIPTION
Fixes #3. Relative paths are left for rollup/other plugins to resolve. This removes the need for changing how the cache works.

This patch introduces a possibly breaking change, see this situation:
```
|- dir
|  \-file.js
|
\- other.js
```

If `file.js` imports from `'./other.js'`, then previously this would refer to the `other.js` file in the root, and after this patch this will refer to `other.js` in the `dir` directory (which doesn't exist and will result in an error).
In my opinion this is more intuitive, because the file in the root dir should be imported by using `'other.js'` (without `./` at the beginning).