### PR TITLE
Use indexOf instead of startsWith

### DIFF
--- a/src/plugin.es5.js
+++ b/src/plugin.es5.js
@@ -169,7 +169,7 @@ var RollupIncludePaths = function () {
     }, {
         key: 'getCacheKey',
         value: function getCacheKey(id, origin) {
-            var isRelativePath = id.startsWith('.');
+            var isRelativePath = id.indexOf('.') === 0;
 
             return isRelativePath ? origin + ':' + id : id;
         }
@@ -331,5 +331,4 @@ function plugin(options) {
         }
     };
 }
-
 module.exports = exports['default'];

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -137,7 +137,7 @@ class RollupIncludePaths {
     }
 
     getCacheKey(id, origin) {
-        const isRelativePath = id.startsWith('.');
+        const isRelativePath = id.indexOf('.') === 0;
 
         return isRelativePath ? `${origin}:${id}` : id;
     }


### PR DESCRIPTION
startsWith doesn't exist in node v0.12.9, so this PR uses indexOf instead. In theory, babel should polyfill this for us but I'm not sure how to configure it.